### PR TITLE
Fixes for returning `Quantity` objects from Dask Futures

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: 3.9
           toxenv: py39
         - os: ubuntu-latest
-          python-version: 3.10
+          python-version: "3.10"
           toxenv: py310
         - os: ubuntu-latest
           python-version: "3.11"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,28 +16,28 @@ jobs:
         include:
         # Test the oldest and newest configuration on Mac and Windows
         - os: macos-latest
-          python-version: 3.8
-          toxenv: py38
+          python-version: 3.9
+          toxenv: py39
         - os: macos-latest
-          python-version: "3.10"
-          toxenv: py310
+          python-version: "3.11"
+          toxenv: py311
         # Test all configurations on Linux
-        - os: ubuntu-latest
-          python-version: 3.8
-          toxenv: py38
         - os: ubuntu-latest
           python-version: 3.9
           toxenv: py39
         - os: ubuntu-latest
-          python-version: "3.10"
+          python-version: 3.10
           toxenv: py310
+        - os: ubuntu-latest
+          python-version: "3.11"
+          toxenv: py311
         # Docs
         - os: ubuntu-latest
-          python-version: "3.10"
+          python-version: "3.11"
           toxenv: build_docs
         # Code style checks
         - os: ubuntu-latest
-          python-version: "3.10"
+          python-version: "3.11"
           toxenv: codestyle
 
     steps:

--- a/synthesizAR/atomic/idl.py
+++ b/synthesizAR/atomic/idl.py
@@ -295,7 +295,7 @@ def spectrum_to_cube(spectrum, wavelength, temperature, density=None, meta=None)
         QuantityTableCoordinate(temperature, physical_types='phys.temperature')
     ).wcs
     spec_cube = ndcube.NDCube(spectrum, wcs=gwcs, meta=meta)
-    if density:
+    if density is not None:
         spec_cube.extra_coords.add('density', (0,), density, physical_types='phys.density')
     return spec_cube
 

--- a/synthesizAR/instruments/hinode.py
+++ b/synthesizAR/instruments/hinode.py
@@ -14,6 +14,7 @@ import xrtpy
 
 from synthesizAR.util import SpatialPair
 from synthesizAR.instruments import InstrumentBase, ChannelBase
+from synthesizAR.util.decorators import return_quantity_as_tuple
 
 __all__ = ['InstrumentHinodeEIS', 'InstrumentHinodeXRT']
 
@@ -91,6 +92,7 @@ class InstrumentHinodeXRT(InstrumentBase):
         return header
 
     @staticmethod
+    @return_quantity_as_tuple
     def calculate_intensity_kernel(loop, channel, **kwargs):
         K_T = np.interp(loop.electron_temperature,
                         channel.temperature,

--- a/synthesizAR/instruments/physical.py
+++ b/synthesizAR/instruments/physical.py
@@ -199,6 +199,7 @@ class InstrumentLOSVelocity(InstrumentQuantityBase):
     name = 'los_velocity'
 
     @staticmethod
+    @return_quantity_as_tuple
     def calculate_intensity_kernel(loop, *args, **kwargs):
         observer = kwargs.get('observer')
         if observer is None:
@@ -210,5 +211,6 @@ class InstrumentTemperature(InstrumentQuantityBase):
     name = 'temperature'
 
     @staticmethod
+    @return_quantity_as_tuple
     def calculate_intensity_kernel(loop, *args, **kwargs):
         return loop.electron_temperature

--- a/synthesizAR/instruments/physical.py
+++ b/synthesizAR/instruments/physical.py
@@ -14,6 +14,7 @@ from sunpy.map import GenericMap
 
 from synthesizAR.instruments import ChannelBase, InstrumentBase
 from synthesizAR.util import los_velocity
+from synthesizAR.util.decorators import return_quantity_as_tuple
 from synthesizAR.instruments.util import add_wave_keys_to_header, extend_celestial_wcs
 
 __all__ = [
@@ -48,7 +49,12 @@ class InstrumentDEM(InstrumentBase):
     def temperature_bin_centers(self) -> u.K:
         return (self.temperature_bin_edges[1:] + self.temperature_bin_edges[:-1])/2
 
+    def get_instrument_name(self, channel):
+        # This ensures that the temperature bin labels are in the header
+        return f'{self.name}_{channel.name}'
+
     @staticmethod
+    @return_quantity_as_tuple
     def calculate_intensity_kernel(loop, channel, **kwargs):
         T = loop.electron_temperature
         n = loop.density
@@ -62,16 +68,22 @@ class InstrumentDEM(InstrumentBase):
         Convert a list of DEM maps to a DEM NDCube
         """
         # NOTE: this is the format that .observe returns
-        dem_list = [dem[c.name][time_index] for c in self.channels]
+        return type(self).dem_maps_list_to_cube(
+            [dem[c.name][time_index] for c in self.channels],
+            self.temperature_bin_centers,
+        )
+
+    @staticmethod
+    def dem_maps_list_to_cube(dem_maps, temperature_bin_centers):
         # Construct WCS
-        compound_wcs = extend_celestial_wcs(dem_list[0].wcs,
-                                            self.temperature_bin_centers,
+        compound_wcs = extend_celestial_wcs(dem_maps[0].wcs,
+                                            temperature_bin_centers,
                                             'temperature',
                                             'phys.temperature')
         # Stack arrays
-        dem_array = u.Quantity([d.quantity for d in dem_list])
+        dem_array = u.Quantity([d.quantity for d in dem_maps])
 
-        return ndcube.NDCube(dem_array, wcs=compound_wcs, )
+        return ndcube.NDCube(dem_array, wcs=compound_wcs, meta=dem_maps[0].meta)
 
     @staticmethod
     def calculate_intensity(dem, spectra, header, meta=None):

--- a/synthesizAR/instruments/sdo.py
+++ b/synthesizAR/instruments/sdo.py
@@ -14,6 +14,7 @@ from aiapy.psf import filter_mesh_parameters
 from scipy.interpolate import interp1d, interpn
 
 from synthesizAR.instruments import InstrumentBase
+from synthesizAR.util.decorators import return_quantity_as_tuple
 
 __all__ = ['InstrumentSDOAIA', 'aia_kernel_quick']
 
@@ -78,6 +79,7 @@ class InstrumentSDOAIA(InstrumentBase):
         return f'{self.detector}_{channel.telescope_number}'
 
     @staticmethod
+    @return_quantity_as_tuple
     def calculate_intensity_kernel(loop, channel, **kwargs):
         em_model = kwargs.get('emission_model', None)
         if em_model:

--- a/synthesizAR/util/decorators.py
+++ b/synthesizAR/util/decorators.py
@@ -1,0 +1,20 @@
+"""
+Useful decorators
+"""
+import functools
+
+import astropy.units as u
+
+__all__ = ['return_quantity_as_tuple']
+
+
+def return_quantity_as_tuple(func):
+    @functools.wraps(func)
+    def wrapper_decorator(*args, **kwargs):
+        # Do something before
+        value = func(*args, **kwargs)
+        if isinstance(value, u.Quantity):
+            return value.value, value.unit.to_string()
+        else:
+            return value
+    return wrapper_decorator

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310}
+    py{39,310,311}
     build_docs
     codestyle
 isolated_build = true

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,14 @@ requires =
 pypi_filter_requirements = https://raw.githubusercontent.com/sunpy/package-template/master/sunpy_version_pins.txt
 
 # Pass through the following environemnt variables which may be needed for the CI
-passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS
+passenv =
+    HOME
+    WINDIR
+    LC_ALL
+    LC_CTYPE
+    CC
+    CI
+    TRAVIS
 
 # Run the tests in a temporary directory to make sure that we don't import
 # the package from the source tree


### PR DESCRIPTION
This PR has some needed quick fixes for returning `astropy.units.Quantity` object from Dask Futures. The root of the problem is described here: dask/distributed#6808.

Additionally, this PR contains several other changes that greatly increase performance when simulating time-dependent emission for many loops. A lot of this code is pretty ugly and it would be good to find a way to deal with these problems in a more elegant way.