### PR TITLE
Add Hinode EIS instrument class

### DIFF
--- a/examples/multi-instrument.py
+++ b/examples/multi-instrument.py
@@ -115,7 +115,7 @@ class InstrumentSTEREOEUVI(InstrumentSDOAIA):
     def __init__(self, *args, **kwargs):
         super().__init__(
             *args,
-            resolution=u.Quantity([1.58777404, 1.58777404], 'arcsec / pixel'),
+            plate_scale=u.Quantity([1.58777404, 1.58777404], 'arcsec / pixel'),
             cadence=1*u.h,
             **kwargs,
         )

--- a/synthesizAR/atomic/emission_models.py
+++ b/synthesizAR/atomic/emission_models.py
@@ -49,6 +49,13 @@ class EmissionModel(fiasco.IonCollection):
         self.emissivity_table_filename = emissivity_table_filename
         self._level_pops_kwargs = kwargs
 
+    def __getitem__(self, value):
+        if isinstance(value, str):
+            # Index by ion roman name. Not calling iterator because this would be circular
+            return {i.ion_name_roman: i for i in self._ion_list}[value]
+        else:
+            return super().__getitem__(value)
+
     @property
     def emissivity_table_filename(self):
         return self._emissivity_table_filename
@@ -110,11 +117,15 @@ class EmissionModel(fiasco.IonCollection):
             _ = self.get_line_emissivity(ion)
             _ = self.get_continuum_emissivity(ion)
 
-    def _get_quantity_from_emissivity_table(self, ion, path):
+    def _get_quantity_from_emissivity_table(self, ion, path, slice=None):
         "Convenience method for retrieving a quantity for a given ion from the Zarr file"
+        slice = np.s_[...] if slice is None else slice
         root = zarr.open(store=self.emissivity_table_filename, mode='r')
         ds = root[f'{ion.ion_name}/{path}']
-        return u.Quantity(ds, ds.attrs.get('unit', ''))
+        if (unit:=ds.attrs.get('unit')) is not None:
+            return u.Quantity(ds[slice], unit)
+        else:
+            return ds[slice]
 
     def _calculate_line_emissivity(self, ion):
         # NOTE: Purposefully not using the contribution_function or emissivity methods on
@@ -132,17 +143,19 @@ class EmissionModel(fiasco.IonCollection):
         else:
             upper_level = ion.transitions.upper_level[ion.transitions.is_bound_bound]
             wavelength = ion.transitions.wavelength[ion.transitions.is_bound_bound]
+            label = ion.transitions.label[ion.transitions.is_bound_bound]
             A = ion.transitions.A[ion.transitions.is_bound_bound]
-            i_upper = fiasco.util.vectorize_where(ion._elvlc['level'], upper_level)
+            i_upper = fiasco.util.vectorize_where(np.arange(1, ion.n_levels+1), upper_level)
             emissivity = pop[:, :, i_upper] * A * u.photon
             emissivity = emissivity[:, :, np.argsort(wavelength)]
+            label = label[np.argsort(wavelength)]
             wavelength = np.sort(wavelength)
             # This is the factor of n_H/n_e * 1/n_e which replaces 0.83 / n_e
             nH_ne2 = np.outer(ion.proton_electron_ratio, 1/self.density)[..., np.newaxis]
             emissivity *= ion.abundance * nH_ne2
-        return wavelength, emissivity
+        return wavelength, label, emissivity
 
-    def get_line_emissivity(self, ion):
+    def get_line_emissivity(self, ion, transition=None):
         r"""
         Get bound-bound emissivity for all lines of a particular ion.
 
@@ -168,17 +181,26 @@ class EmissionModel(fiasco.IonCollection):
         ----------
         ion: `fiasco.Ion`
             Ion instance for which to compute bound-bound line emission.
+        transition: `str`, optional
+            Optionally return only a single transition. The reason for having this is it is faster to read out
+            the emissivity for just one transition rather than reading out the whole array and then slicing.
         """
         root = zarr.open(store=self.emissivity_table_filename, mode='a')
         if root.get(f'{ion.ion_name}/line') is None:
-            wavelength, emissivity = self._calculate_line_emissivity(ion)
+            wavelength, label, emissivity = self._calculate_line_emissivity(ion)
             grp = root.create_group(f'{ion.ion_name}/line')
             ds = grp.create_array('wavelength', data=wavelength.value)
             ds.attrs['unit'] = wavelength.unit.to_string()
+            ds = grp.create_array('label', data=label)
             ds = grp.create_array('emissivity', data=emissivity.value)
             ds.attrs['unit'] = emissivity.unit.to_string()
-        wavelength = self._get_quantity_from_emissivity_table(ion, 'line/wavelength')
-        emissivity = self._get_quantity_from_emissivity_table(ion, 'line/emissivity')
+        if transition is not None:
+            label = self._get_quantity_from_emissivity_table(ion, 'line/label')
+            idx = np.s_[:,:] + np.where(label==transition)
+        else:
+            idx = np.s_[:,:,:]
+        wavelength = self._get_quantity_from_emissivity_table(ion, 'line/wavelength', slice=idx[-1])
+        emissivity = self._get_quantity_from_emissivity_table(ion, 'line/emissivity', slice=idx)
         return wavelength, emissivity
 
     def _calculate_continuum_emissivity(self, ion):

--- a/synthesizAR/instruments/base.py
+++ b/synthesizAR/instruments/base.py
@@ -48,7 +48,7 @@ class InstrumentBase:
         as the times at which the observations should be forward modeled.
     observer : `~astropy.coordinates.SkyCoord`
         Coordinate of the observing instrument
-    resolution : `~astropy.units.Quantity`
+    plate_scale : `~astropy.units.Quantity`
     cadence : `~astropy.units.Quantity`, optional
         If specified, this is used to construct the observing time.
     pad_fov : `~astropy.units.Quantity`, optional
@@ -66,21 +66,26 @@ class InstrumentBase:
         Set to true for non-volumetric quantities
     """
 
-    @u.quantity_input
+    @u.quantity_input(observing_time=u.s,
+                      plate_scale=u.arcsec/u.pix,
+                      cadence=u.s,
+                      pad_fov=u.pixel,
+                      fov_width=(u.arcsec, u.pixel),
+                      rotation_angle=u.deg,)
     def __init__(self,
-                 observing_time: u.s,
+                 observing_time,
                  observer,
-                 resolution: u.Unit('arcsec/pix'),
-                 cadence: u.s = None,
-                 pad_fov: u.pixel = None,
-                 fov_center = None,
-                 fov_width: u.arcsec = None,
-                 rotation_angle: u.deg = None,
+                 plate_scale,
+                 cadence=None,
+                 pad_fov=None,
+                 fov_center=None,
+                 fov_width=None,
+                 rotation_angle=None,
                  average_over_los=False):
         self.observer = observer
         self.cadence = cadence
         self.observing_time = observing_time
-        self.resolution = resolution
+        self.plate_scale = plate_scale
         self.pad_fov = pad_fov
         self.fov_center = fov_center
         self.fov_width = fov_width
@@ -108,12 +113,12 @@ class InstrumentBase:
         self._cadence = value
 
     @property
-    def resolution(self) -> u.arcsec/u.pix:
-        return self._resolution
+    def plate_scale(self) -> u.arcsec/u.pix:
+        return self._plate_scale
 
-    @resolution.setter
-    def resolution(self, value):
-        self._resolution = value
+    @plate_scale.setter
+    def plate_scale(self, value):
+        self._plate_scale = value
 
     @property
     def rotation_angle(self) -> u.deg:
@@ -178,7 +183,7 @@ class InstrumentBase:
         Cartesian area on the surface of the Sun covered by a single pixel.
         """
         sa_equiv = solar_angle_equivalency(self.observer)
-        res = (1*u.pix * self.resolution).to('cm', equivalencies=sa_equiv)
+        res = (1*u.pix * self.plate_scale).to('cm', equivalencies=sa_equiv)
         return res[0] * res[1]
 
     def convolve_with_psf(self, smap, channel):
@@ -468,7 +473,7 @@ class InstrumentBase:
             tuple(n_pixels[::-1].to_value('pixel')),  # swap order because it expects (row,column)
             ref_coord,
             reference_pixel=(n_pixels - 1*u.pix) / 2,  # center of lower left pixel is (0,0)
-            scale=self.resolution,
+            scale=self.plate_scale,
             rotation_angle=self.rotation_angle,
             observatory=self.observatory,
             instrument=instrument,
@@ -487,7 +492,10 @@ class InstrumentBase:
         """
         if self.fov_center is not None and self.fov_width is not None:
             center = self.fov_center.transform_to(self.projected_frame)
-            n_pixels = (self.fov_width / self.resolution).decompose().to('pixel')
+            if u.get_physical_type(self.fov_width) == 'angle':
+                n_pixels = (self.fov_width / self.plate_scale).decompose().to('pixel')
+            else:
+                n_pixels = self.fov_width.to('pixel')
         else:
             # If not specified, derive FOV from loop coordinates
             coordinates = coordinates.transform_to(self.projected_frame)
@@ -497,8 +505,8 @@ class InstrumentBase:
             center = SkyCoord(Tx=bottom_left_corner.Tx+delta_x/2,
                               Ty=bottom_left_corner.Ty+delta_y/2,
                               frame=bottom_left_corner.frame)
-            pixels_x = int(np.ceil((delta_x / self.resolution[0]).decompose()).value)
-            pixels_y = int(np.ceil((delta_y / self.resolution[1]).decompose()).value)
+            pixels_x = int(np.ceil((delta_x / self.plate_scale[0]).decompose()).value)
+            pixels_y = int(np.ceil((delta_y / self.plate_scale[1]).decompose()).value)
             n_pixels = u.Quantity([pixels_x, pixels_y], 'pixel')
             n_pixels += self.pad_fov
         return center, n_pixels

--- a/synthesizAR/instruments/hinode.py
+++ b/synthesizAR/instruments/hinode.py
@@ -1,17 +1,171 @@
 """
-Class for Hinode/EIS instrument. Holds information about spectral, temporal, and spatial resolution
-and other instrument-specific information.
+Classes for Hinode EIS and XRT
 """
 import astropy.units as u
 import numpy as np
+import sunpy.map
 import xrtpy
 
+from astropy.stats import gaussian_fwhm_to_sigma
 from dataclasses import dataclass
+from scipy.interpolate import interpn
 
 from synthesizAR.instruments import ChannelBase, InstrumentBase
 from synthesizAR.util.decorators import return_quantity_as_tuple
 
-__all__ = ['InstrumentHinodeXRT']
+__all__ = ['InstrumentHinodeEIS', 'InstrumentHinodeXRT']
+
+
+@dataclass
+class ChannelEIS:
+    """
+    Parameters
+    ----------
+    line_id: str
+        EIS line identification.
+    transition: str
+        Label of the transition, including configuration and angular momentum
+        of upper and lower energy level.
+    """
+    line_id: str
+    transition: str
+    # See https://solarb.mssl.ucl.ac.uk/SolarB/eis_docs/eis_notes/08_COMA/eis_swnote_08.pdf
+    psf_width: u.Quantity = (3, 3)*u.pixel*gaussian_fwhm_to_sigma
+
+    def __post_init__(self):
+        el, ion, wave = self.line_id.split()
+        self.ion_name = f'{el} {ion}'
+        self.wavelength = float(wave) * u.AA
+        self.name = self.line_id
+        self.channel = self.wavelength
+
+
+class InstrumentHinodeEIS(InstrumentBase):
+    """
+    Instrument object for computing intensities as observed by the EUV Imaging Spectrometer onboard _Hinode_.
+
+    This instrument class produces an intensity map per timestep in physical units, i.e. :math:`erg cm^{-2} s^{-1} sr^{-1}`.
+    It does not include a wavelength dimension. The modeled intensity should be interpreted as the peak intensity of the line profile.
+
+    Parameters
+    ----------
+    observing_time: `~astropy.units.Quantity`
+        Observing time range
+    observer: `~astropy.coordinates.SkyCoord`
+        Observer location
+    lines: `list`
+        List of tuples specifying the EIS lines to synthesize. Each entry should be a tuple of strings
+        where the first entry is the line ID and the second is the transition, e.g.
+        ``('S XIII 256.686', '2s 2p 1P1 -- 2s2 1S0')``. It is best if the line IDs are consistent with those
+        used by the EIS software.
+    """
+    name = 'Hinode_EIS'
+
+    def __init__(self, observing_time, observer, lines, **kwargs):
+        self._lines = lines
+        plate_scale = kwargs.pop('plate_scale', [2.99519992, 1.0]*u.arcsec/u.pixel)
+        fov_width = kwargs.pop('fov_width', [87, 512]*u.pixel)
+        cadence = kwargs.pop('cadence', 41.89655172413793*u.s)
+        super().__init__(
+            observing_time=observing_time,
+            observer=observer,
+            plate_scale=plate_scale,
+            cadence=cadence,
+            fov_width=fov_width,
+            **kwargs,
+        )
+
+    @property
+    def channels(self):
+        return [ChannelEIS(*line) for line in self._lines]
+
+    @property
+    def observatory(self):
+        return 'Hinode'
+
+    @property
+    def telescope(self):
+        return 'Hinode'
+
+    @property
+    def detector(self):
+        return 'EIS'
+
+    def get_instrument_name(self, channel):
+        # This is explicitly not just EIS so that the eispac EIS map source
+        # is not used for these time-dependent files
+        return f'{self.telescope}_{self.detector}'
+
+    @property
+    def _expected_unit(self):
+        return u.Unit('erg cm-2 s-1 sr-1')
+
+    def get_header(self, *args, **kwargs):
+        header = super().get_header(*args, **kwargs)
+        if (channel:=kwargs.get('channel')) is not None:
+            header['line_id'] = channel.line_id
+            header['measrmnt'] = 'intensity'
+            header['lvl_num'] = 2
+        return header
+
+    @staticmethod
+    @return_quantity_as_tuple
+    def calculate_intensity_kernel(loop, channel, **kwargs):
+        if (em_model:=kwargs.get('emission_model')) is None:
+            raise ValueError('Must pass an EmissionModel instance to .observe()')
+        # Get line emissivity from model
+        ion = em_model[channel.ion_name]
+        wavelength, em_ion = em_model.get_line_emissivity(ion, transition=channel.transition)
+        # Reshape temperature and density arrays
+        n = loop.density
+        T = loop.electron_temperature
+        Tn_flat = np.stack((T.value.flatten(), n.value.flatten()), axis=1)
+        # Interpolate emissivity to loop n, T
+        em_flat = interpn(
+            (em_model.temperature.to_value(T.unit), em_model.density.to_value(n.unit)),
+            em_ion.squeeze().value,
+            Tn_flat,
+            method='linear',
+            fill_value=0.0,  # No emission outside of model bounds
+            bounds_error=False,
+        )
+        em_ion_interp = np.reshape(em_flat, T.shape)
+        em_ion_interp = u.Quantity(np.where(em_ion_interp<0, 0, em_ion_interp), em_ion.unit)
+        # Apply conversion factors
+        ionization_fraction = loop.get_ionization_fraction(ion)
+        erg_per_ph = wavelength.to('erg', equivalencies=u.equivalencies.spectral()) / u.photon
+        kernel = erg_per_ph*ionization_fraction*em_ion_interp*n**2/(4*np.pi*u.steradian)
+        return kernel
+
+    @staticmethod
+    def build_raster_map(maps):
+        """
+        Build a single map from a series of per-exposure maps.
+
+        Parameters
+        ----------
+        maps: `list` or `~sunpy.map.MapSequence`
+        """
+        # TODO: make this more flexible to allow for producing multiple rasters
+        # in the case where the number of maps exceeds the x-dimension of the map
+        maps = sunpy.map.Map(maps, sequence=True)
+        if not maps.all_same_shape:
+            raise ValueError('All maps must be the same shape')
+        shape = maps[0].data.shape
+        idx_last = min(shape[1]-1, len(maps)-1)
+        # Update metadata
+        new_meta = maps[0].meta.copy()
+        new_meta['date-beg'] = maps[0].date.isot
+        new_meta['date-end'] = maps[idx_last].date.isot
+        new_meta['date-avg'] = (maps[0].date + (maps[idx_last].date - maps[0].date)/2).isot
+        new_meta['date-obs'] = maps[0].date_average.isot
+        # This is reset here to ensure that the EISPAC map source is used.
+        new_meta['instrume'] = 'EIS'
+        # Build raster map
+        new_data = np.nan*np.ones(shape)
+        for i in range(idx_last+1):
+            new_data[:,shape[1]-1-i] = maps[i].data[:,shape[1]-1-i]
+        return sunpy.map.Map(new_data, new_meta)
 
 
 @dataclass
@@ -27,16 +181,28 @@ class ChannelXRT(ChannelBase):
 
 
 class InstrumentHinodeXRT(InstrumentBase):
+    """
+    Instrument object for computing images as observed by Hinode XRT.
+
+    Parameters
+    ----------
+    observing_time: `~astropy.units.Quantity`
+        Observing time range
+    observer: `~astropy.coordinates.SkyCoord`
+        Observer location
+    filters: `list`
+        List of filter label strings. It is assumed that the other filter is open.
+    """
     name = 'Hinode_XRT'
 
     def __init__(self, observing_time, observer, filters, **kwargs):
-        resolution = kwargs.pop('resolution', [2.05719995499, 2.05719995499] * u.arcsec/u.pixel)
+        plate_scale = kwargs.pop('plate_scale', [2.05719995499, 2.05719995499] * u.arcsec/u.pixel)
         cadence = kwargs.pop('cadence', 20 * u.s)
         self._filters = filters
         super().__init__(
             observing_time=observing_time,
             observer=observer,
-            resolution=resolution,
+            plate_scale=plate_scale,
             cadence=cadence,
             **kwargs
         )

--- a/synthesizAR/instruments/sdo.py
+++ b/synthesizAR/instruments/sdo.py
@@ -75,12 +75,12 @@ class InstrumentSDOAIA(InstrumentBase):
     name = 'SDO_AIA'
 
     def __init__(self, observing_time, observer, **kwargs):
-        resolution = kwargs.pop('resolution', [0.600698, 0.600698] * u.arcsec/u.pixel)
+        plate_scale = kwargs.pop('plate_scale', [0.600698, 0.600698] * u.arcsec/u.pixel)
         cadence = kwargs.pop('cadence', 12.0 * u.s)
         super().__init__(
             observing_time=observing_time,
             observer=observer,
-            resolution=resolution,
+            plate_scale=plate_scale,
             cadence=cadence,
             **kwargs,
         )

--- a/synthesizAR/instruments/tests/test_sdo.py
+++ b/synthesizAR/instruments/tests/test_sdo.py
@@ -32,10 +32,10 @@ def test_aia_observing_times(earth_observer, input, result):
 
 
 @pytest.mark.remote_data
-def test_aia_resolution(earth_observer):
+def test_aia_plate_scale(earth_observer):
     aia = InstrumentSDOAIA([0,]*u.s, earth_observer)
-    assert u.allclose(aia.resolution, [0.600698, 0.600698]*u.arcsec/u.pix)
+    assert u.allclose(aia.plate_scale, [0.600698, 0.600698]*u.arcsec/u.pix)
     aia = InstrumentSDOAIA([0,]*u.s,
                            earth_observer,
-                           resolution=[1.2,1.2] * u.arcsec / u.pix)
-    assert u.allclose(aia.resolution, [1.2,1.2] * u.arcsec / u.pix)
+                           plate_scale=[1.2,1.2] * u.arcsec / u.pix)
+    assert u.allclose(aia.plate_scale, [1.2,1.2] * u.arcsec / u.pix)


### PR DESCRIPTION
Fixes #12 
Fixes #106 
Fixes #112 

This PR adds an instrument class for computing peak line intensities in physical units as observed by Hinode EIS. 

This PR also modifies the emission model to store transition label info and allow for selecting only specific transitions.

You can also now specify the FoV in pixels in addition to arcseconds. This is useful when the FoV of an instrument is limited explicitly by detector size.