### PR TITLE
Compute temperature response for a given emission model

### DIFF
--- a/synthesizAR/atomic/emission_models.py
+++ b/synthesizAR/atomic/emission_models.py
@@ -8,6 +8,7 @@ import numpy as np
 import pathlib
 import zarr
 
+from collections import Counter
 from fiasco.util.exceptions import MissingDatasetException
 from functools import cache
 from scipy.integrate import trapezoid
@@ -48,12 +49,18 @@ class EmissionModel(fiasco.IonCollection):
         self.density = density
         self.emissivity_table_filename = emissivity_table_filename
         self._level_pops_kwargs = kwargs
+        # No duplicate ions allowed due to indexing by ion name
+        ion_names = Counter([i.ion_name for i in self._ion_list])
+        if (duplicates := [i for i,c in ion_names.items() if c>1]):
+            raise ValueError(f'Cannot pass duplicate ions {duplicates} to emission model.')
+
 
     def __getitem__(self, value):
         if isinstance(value, str):
             # Index by ion roman name. Not calling iterator because this would be circular
             return {i.ion_name_roman: i for i in self._ion_list}[value]
         else:
+            # FIXME: Allow for slicing, actually return an EmissionModel instance
             return super().__getitem__(value)
 
     @property
@@ -106,7 +113,7 @@ class EmissionModel(fiasco.IonCollection):
         )
         return em_model
 
-    def build_emissivity_table(self):
+    def build_emissivity_table(self, progress=True):
         """
         Save line and continuum emissivity to a Zarr file.
 
@@ -115,7 +122,12 @@ class EmissionModel(fiasco.IonCollection):
         to call this function as emissivities will be automatically calculated and stored as
         needed, but it may be convenient in some instances.
         """
-        for ion in self:
+        if progress:
+            import tqdm
+            iterator = tqdm.tqdm(self)
+        else:
+            iterator = self
+        for ion in iterator:
             self.log.debug(f'Calculating emissivity for {ion.ion_name}.')
             _ = self.get_line_emissivity(ion)
             _ = self.get_continuum_emissivity(ion)
@@ -301,6 +313,10 @@ class EmissionModel(fiasco.IonCollection):
         """
         wavelength = channel.wavelength
         response = channel.wavelength_response()
+        # NOTE: Can remove this logic once AIA Channel class is compatible with sunkit-instrument
+        # response function API
+        if u.steradian not in response.unit.bases:
+            response *= channel.plate_scale
         f_interp = interp1d(wavelength, response, bounds_error=False, fill_value=0.0)
         # Bound-bound line emissivity
         transition_wavelengths, line_emissivity = self.get_line_emissivity(ion)
@@ -317,7 +333,7 @@ class EmissionModel(fiasco.IonCollection):
         return emissivity
 
     @u.quantity_input
-    def calculate_temperature_response(self, channel) -> u.Unit('cm5 DN pixel-1 s-1'):
+    def calculate_temperature_response(self, channel, ion=None) -> u.Unit('cm5 DN pixel-1 s-1'):
         r"""
         Compute the temperature response function of a given channel for all ions in the model.
 
@@ -332,15 +348,25 @@ class EmissionModel(fiasco.IonCollection):
         Parameters
         ----------
         channel : Compatible with `sunkit_instruments.response.abstractions.AbstractChannel`
+            Channel for which to compute the temperature response function
+        ion: `~fiasco.Ion`, optional
+            The ion to compute the temperature response for. This is useful when analyzing the
+            contribution of a given ion to the temperature response of a channel. This ion must
+            be a part of the emission model. If not specified, all ions in the collection are included.
         """
         if self.density.shape[0] > 1 and not self._level_pops_kwargs.get('couple_density_to_temperature', False):
             raise ValueError(
                 'Can only compute temperature response for a single density entry or aligned temperature and density axes.'
             )
+        if ion is not None:
+            ion_list = [ion,]
+        else:
+            ion_list = self
         temperature_response = np.zeros(self.temperature.shape) * u.Unit('cm5 DN sr pixel-1 s-1')
-        for ion in self:
-            emiss = self.calculate_narrowband_emissivity(ion, channel).squeeze().copy()
-            emiss *= ion.ionization_fraction
+        for _ion in ion_list:
+            emiss = self.calculate_narrowband_emissivity(_ion, channel).squeeze().copy()
+            # NOTE: ionization fraction can be NaN outside of database temperature data
+            emiss *= np.where(np.isnan(_ion.ionization_fraction), 0, _ion.ionization_fraction)
             temperature_response += emiss
         temperature_response /= 4*np.pi*u.steradian
         return temperature_response

--- a/synthesizAR/atomic/emission_models.py
+++ b/synthesizAR/atomic/emission_models.py
@@ -76,7 +76,10 @@ class EmissionModel(fiasco.IonCollection):
             'emissivity_table_filename': self.emissivity_table_filename.as_posix(),
             'level_pops_kwargs': self._level_pops_kwargs,
             'ions': [ion.ion_name for ion in self],
-            'ion_kwargs': [ion._instance_kwargs for ion in self]
+            'ion_kwargs': [
+                {k: str(v) if isinstance(v, pathlib.Path) else v for k,v in ion._instance_kwargs.items()}
+                for ion in self
+            ]
         }
         with asdf.AsdfFile(tree) as asdf_file:
             asdf_file.write_to(filename)
@@ -139,7 +142,12 @@ class EmissionModel(fiasco.IonCollection):
             # NOTE: populations not available for every ion
             self.log.warning(f'Cannot compute level populations for {ion.ion_name}')
             wavelength = [0]*u.AA
-            emissivity = u.Quantity(np.zeros(self.temperature.shape+self.density.shape+(1,)), 'cm3 ph s-1')
+            label = np.array([''])
+            if self._level_pops_kwargs.get('couple_density_to_temperature', False):
+                default_shape = self.temperature.shape+(1,1,)
+            else:
+                default_shape = self.temperature.shape+self.density.shape+(1,)
+            emissivity = u.Quantity(np.zeros(default_shape), 'cm3 ph s-1')
         else:
             upper_level = ion.transitions.upper_level[ion.transitions.is_bound_bound]
             wavelength = ion.transitions.wavelength[ion.transitions.is_bound_bound]
@@ -151,7 +159,11 @@ class EmissionModel(fiasco.IonCollection):
             label = label[np.argsort(wavelength)]
             wavelength = np.sort(wavelength)
             # This is the factor of n_H/n_e * 1/n_e which replaces 0.83 / n_e
-            nH_ne2 = np.outer(ion.proton_electron_ratio, 1/self.density)[..., np.newaxis]
+            if self._level_pops_kwargs.get('couple_density_to_temperature', False):
+                nH_ne2 = ion.proton_electron_ratio / self.density
+                nH_ne2 = nH_ne2[:, np.newaxis, np.newaxis]
+            else:
+                nH_ne2 = np.outer(ion.proton_electron_ratio, 1/self.density)[..., np.newaxis]
             emissivity *= ion.abundance * nH_ne2
         return wavelength, label, emissivity
 
@@ -303,3 +315,32 @@ class EmissionModel(fiasco.IonCollection):
                                  axis=-1) * integrand.unit*continuum_wavelength.unit
         emissivity += em_continuum[:, np.newaxis]
         return emissivity
+
+    @u.quantity_input
+    def calculate_temperature_response(self, channel) -> u.Unit('cm5 DN pixel-1 s-1'):
+        r"""
+        Compute the temperature response function of a given channel for all ions in the model.
+
+        The temperature response is given by,
+
+        .. math::
+
+            K_c(T) = \frac{1}{4\pi}\Sum_{X,k}f_{X,k}\epsilon_{c,X,k},
+
+        where :math:`\epsilon` is the emissivity computed by `~synthesizAR.atomic.EmissionModel.calculate_narrowband_emissivity`.
+
+        Parameters
+        ----------
+        channel : Compatible with `sunkit_instruments.response.abstractions.AbstractChannel`
+        """
+        if self.density.shape[0] > 1 and not self._level_pops_kwargs.get('couple_density_to_temperature', False):
+            raise ValueError(
+                'Can only compute temperature response for a single density entry or aligned temperature and density axes.'
+            )
+        temperature_response = np.zeros(self.temperature.shape) * u.Unit('cm5 DN sr pixel-1 s-1')
+        for ion in self:
+            emiss = self.calculate_narrowband_emissivity(ion, channel).squeeze().copy()
+            emiss *= ion.ionization_fraction
+            temperature_response += emiss
+        temperature_response /= 4*np.pi*u.steradian
+        return temperature_response


### PR DESCRIPTION
This PR adds a method for computing the temperature response for an emission model given a channel that defines a wavelength response function. There are also some minor tweaks to allow for aligned temperature and density axes in the precomputed emissivities.